### PR TITLE
feat: add popover comp (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@floating-ui/react-dom": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.90.16",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@floating-ui/react-dom':
+        specifier: ^2.1.7
+        version: 2.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
@@ -718,6 +721,21 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@floating-ui/core@1.7.4':
+    resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
+
+  '@floating-ui/dom@1.7.5':
+    resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
+
+  '@floating-ui/react-dom@2.1.7':
+    resolution: {integrity: sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3773,6 +3791,23 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@floating-ui/core@1.7.4':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.5':
+    dependencies:
+      '@floating-ui/core': 1.7.4
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@floating-ui/dom': 1.7.5
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@floating-ui/utils@0.2.10': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/src/shared/ui/Popover/Popover.tsx
+++ b/src/shared/ui/Popover/Popover.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Placement } from '@floating-ui/react-dom';
+import React from 'react';
+
+import PopoverContent from './PopoverContent';
+import PopoverProvider from './PopoverProvider';
+import PopoverTrigger from './PopoverTrigger';
+
+interface PopoverProps {
+  children: React.ReactNode;
+  placement?: Placement; // Popover의 기본 표시 위치
+}
+
+/**
+ * @example
+ * <Popover placement="bottom-start">
+ *   <Popover.Trigger popoverKey="menu">
+ *     <Button>메뉴 열기</Button>
+ *   </Popover.Trigger>
+ *   <Popover.Content popoverKey="menu">
+ *     {close => <div>메뉴 내용</div>}
+ *   </Popover.Content>
+ * </Popover>
+ */
+const Popover = ({ children, placement = 'bottom-start' }: PopoverProps) => {
+  return <PopoverProvider placement={placement}>{children}</PopoverProvider>;
+};
+
+Popover.Trigger = PopoverTrigger;
+Popover.Content = PopoverContent;
+
+export default Popover;

--- a/src/shared/ui/Popover/PopoverContent.tsx
+++ b/src/shared/ui/Popover/PopoverContent.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useOutsideDismiss } from '@/shared/utils/useOutsideDismiss';
+import clsx from 'clsx';
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { usePopover } from './PopoverContext';
+import { usePopoverPosition } from './usePopoverPosition';
+
+interface PopoverContentProps {
+  children: (close: () => void) => React.ReactNode; // render props 패턴으로 close 함수를 전달
+  popoverKey: string; // 어떤 Popover인지 구분하는 고유 키
+  className?: string;
+}
+
+// Popover의 실제 내용을 표시하는 컴포넌트, Portal을 통해 body에 렌더링되며 Floating UI로 위치를 계산
+const PopoverContent = ({ children, popoverKey, className }: PopoverContentProps) => {
+  const { activeKey, anchorEl, placement, close } = usePopover();
+
+  // 현재 이 Content가 활성화되어 있는지 확인
+  const isActive = activeKey === popoverKey;
+
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const anchorRef = useRef<HTMLElement | null>(null);
+
+  // anchorEl이 변경될 때마다 ref 업데이트 (useEffect 내부에서 처리)
+  useEffect(() => {
+    anchorRef.current = anchorEl ?? null;
+  }, [anchorEl]);
+
+  // Floating UI를 사용한 위치 계산
+  const { refs, floatingStyles } = usePopoverPosition(anchorEl ?? null, isActive, placement);
+
+  // 외부 클릭 시 닫기 처리
+  useOutsideDismiss([anchorRef, contentRef], {
+    onDismiss: close,
+    closeOnEsc: true,
+    enabled: isActive, // 열려있을 때만 활성화
+  });
+
+  // 비활성 상태면 렌더링하지 않음
+  if (!isActive || typeof document === 'undefined') return null;
+
+  // Portal을 통해 body에 렌더링
+  return createPortal(
+    <div
+      ref={node => {
+        refs.setFloating(node);
+        contentRef.current = node;
+      }}
+      style={floatingStyles}
+      className={clsx(
+        'border-gray100 bg-gray50 z-50 m-1 rounded-2xl border shadow-[0_1px_3px_1px_rgba(0,0,0,0.08),0_1px_5px_2px_rgba(0,0,0,0.02)]',
+        className
+      )}
+      aria-modal="false"
+      role="dialog"
+    >
+      {children(close)}
+    </div>,
+    document.body
+  );
+};
+
+export default PopoverContent;

--- a/src/shared/ui/Popover/PopoverContext.ts
+++ b/src/shared/ui/Popover/PopoverContext.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { Placement } from '@floating-ui/react-dom';
+import { createContext, useContext } from 'react';
+
+interface PopoverContextType {
+  anchorEl?: HTMLElement | null; // Popover가 기준으로 삼을 요소 (Trigger)
+  activeKey: string | null; // 현재 열려있는 Popover의 키
+  placement: Placement; // Popover의 표시 위치
+  close: () => void; // Popover를 닫는 함수
+  open: (key: string, anchor: HTMLElement) => void; // Popover를 여는 함수
+  toggle: (key: string, anchor: HTMLElement) => void; // Popover를 토글하는 함수
+}
+
+export const PopoverContext = createContext<PopoverContextType | undefined>(undefined);
+
+// Popover Context를 사용하기 위한 커스텀 훅
+export const usePopover = () => {
+  const context = useContext(PopoverContext);
+  if (!context) {
+    throw new Error('usePopover는 PopoverProvider 내부에서만 사용해야합니다.');
+  }
+
+  return context;
+};

--- a/src/shared/ui/Popover/PopoverProvider.tsx
+++ b/src/shared/ui/Popover/PopoverProvider.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Placement } from '@floating-ui/react-dom';
+import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
+
+import { PopoverContext } from './PopoverContext';
+
+// Popover의 상태를 관리하고 Context를 제공하는 Provider 컴포넌트
+const PopoverProvider = ({ children, placement }: PropsWithChildren<{ placement: Placement }>) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null); // Trigger 요소
+  const [activeKey, setActiveKey] = useState<string | null>(null); // 활성화된 Popover 키
+
+  // Popover 열기
+  const open = useCallback((key: string, anchor: HTMLElement) => {
+    setActiveKey(key);
+    setAnchorEl(anchor);
+  }, []);
+
+  // Popover 닫기
+  const close = useCallback(() => {
+    setActiveKey(null);
+    setAnchorEl(null);
+  }, []);
+
+  // Popover 토글 (같은 키면 닫고, 다른 키면 열기)
+  const toggle = useCallback(
+    (key: string, anchor: HTMLElement) => {
+      if (activeKey === key && anchorEl === anchor) close();
+      else open(key, anchor);
+    },
+    [activeKey, anchorEl, close, open]
+  );
+
+  const value = useMemo(
+    () => ({
+      anchorEl,
+      activeKey,
+      placement,
+      open,
+      close,
+      toggle,
+    }),
+    [anchorEl, activeKey, placement, open, close, toggle]
+  );
+
+  return <PopoverContext.Provider value={value}>{children}</PopoverContext.Provider>;
+};
+
+export default PopoverProvider;

--- a/src/shared/ui/Popover/PopoverTrigger.tsx
+++ b/src/shared/ui/Popover/PopoverTrigger.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { ReactElement, cloneElement, useRef } from 'react';
+
+import { usePopover } from './PopoverContext';
+
+// Trigger가 되는 컴포넌트가 가져야 할 최소한의 props
+interface TriggerProps {
+  ref?: React.Ref<HTMLElement>;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  'aria-label'?: string;
+  'aria-haspopup'?: boolean;
+  'aria-expanded'?: boolean;
+}
+
+interface PopoverTriggerProps {
+  children: ReactElement<TriggerProps>; // ref와 onClick을 받을 수 있는 컴포넌트
+  popoverKey: string; // 어떤 Popover를 제어할지 구분하는 키
+  ariaLabel?: string;
+}
+
+// children으로 받은 컴포넌트에 onClick과 ref를 주입
+const PopoverTrigger = ({ children, popoverKey, ariaLabel }: PopoverTriggerProps) => {
+  const triggerRef = useRef<HTMLElement>(null);
+  const { activeKey, toggle } = usePopover();
+
+  // 현재 이 Trigger의 Popover가 열려있는지 확인 (key 상태 확인)
+  const isActive = activeKey === popoverKey;
+
+  const handleInteraction = (e: React.MouseEvent<HTMLElement>) => {
+    // 원래 children의 onClick이 있다면 실행
+    children.props.onClick?.(e);
+
+    // Popover 토글
+    if (triggerRef.current) {
+      toggle(popoverKey, triggerRef.current);
+    }
+  };
+
+  // children의 ref를 안전하게 추출하고 타입 지정
+  const childRef = ('ref' in children ? children.ref : undefined) as
+    | React.Ref<HTMLElement>
+    | undefined;
+
+  // ref callback을 직접 정의
+  // 렌더링 시마다 새 함수가 생성되지만 ref는 실제 DOM 노드가 마운트/업데이트될 때만 호출됨
+  const handleRef = (node: HTMLElement | null) => {
+    // triggerRef 업데이트
+    triggerRef.current = node;
+
+    // childRef가 있으면 전달
+    if (typeof childRef === 'function') {
+      childRef(node);
+    } else if (childRef && 'current' in childRef) {
+      // ref 객체인 경우 current 업데이트
+      // ESLint는 ref.current 수정을 경고하지만, 이는 ref callback 내부에서 안전
+      // eslint-disable-next-line react-hooks/immutability
+      (childRef as React.MutableRefObject<HTMLElement | null>).current = node;
+    }
+  };
+
+  return cloneElement(children, {
+    ref: handleRef,
+    onClick: handleInteraction,
+    // 접근성 속성 추가
+    'aria-haspopup': true,
+    'aria-expanded': isActive,
+    'aria-label': ariaLabel || children.props['aria-label'],
+  } as Partial<TriggerProps>);
+};
+
+export default PopoverTrigger;

--- a/src/shared/ui/Popover/usePopoverPosition.ts
+++ b/src/shared/ui/Popover/usePopoverPosition.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { Placement, flip, offset, shift, useFloating } from '@floating-ui/react-dom';
+import { useEffect } from 'react';
+
+/**
+ * Floating UI를 사용하여 Popover의 위치를 계산하는 커스텀 훅
+ *
+ * @param triggerRef - Popover가 기준으로 삼을 요소 (trigger)
+ * @param isOpen - Popover가 열려있는지 여부 (열려있을 때만 위치 계산)
+ * @param placement - Popover의 기본 표시 위치
+ * @returns Floating UI의 refs와 스타일
+ */
+export const usePopoverPosition = (
+  triggerRef: HTMLElement | null,
+  isOpen: boolean,
+  placement: Placement = 'bottom-start'
+) => {
+  const { refs, floatingStyles, update } = useFloating({
+    placement,
+    middleware: [
+      offset(6), // 기준 요소로부터의 거리
+      flip(), // 화면 공간에 맞춰 위아래로 뒤집기
+      shift(), // 화면 밖으로 나가지 않도록 옆으로 밀어넣기
+    ],
+  });
+
+  // Trigger 요소를 Floating UI에 연결
+  useEffect(() => {
+    refs.setReference(triggerRef);
+  }, [triggerRef, refs]);
+
+  // Popover가 열릴 때마다 위치 업데이트
+  useEffect(() => {
+    if (isOpen) update();
+  }, [isOpen, update]);
+
+  return { refs, floatingStyles };
+};

--- a/src/shared/utils/useOutsideDismiss.ts
+++ b/src/shared/utils/useOutsideDismiss.ts
@@ -6,16 +6,27 @@ interface UseOutsideDismissOptions {
   enabled?: boolean;
 }
 
+/**
+ * 외부 클릭 시 dismiss 처리를 위한 커스텀 훅
+ * 여러 개의 ref를 받아서 모두 제외 대상으로 처리 가능
+ */
 export function useOutsideDismiss<T extends HTMLElement | null>(
-  ref: React.RefObject<T> | null,
+  ref: React.RefObject<T> | React.RefObject<T>[] | null,
   { onDismiss, closeOnEsc = true, enabled = true }: UseOutsideDismissOptions
 ) {
   useEffect(() => {
-    if (!ref || !ref.current || !enabled) return;
+    if (!enabled) return;
+
+    // ref를 배열로 정규화
+    const refs = Array.isArray(ref) ? ref : [ref];
 
     const onPointerDown = (e: PointerEvent) => {
-      if (!ref.current) return;
-      if (!ref.current.contains(e.target as Node)) {
+      // 모든 ref를 확인해서 하나라도 클릭 대상을 포함하고 있으면 무시
+      const isInside = refs.some(r => {
+        return r && r.current && r.current.contains(e.target as Node);
+      });
+
+      if (!isInside) {
         onDismiss();
       }
     };
@@ -26,7 +37,8 @@ export function useOutsideDismiss<T extends HTMLElement | null>(
       }
     };
 
-    // 즉시 등록 (rAF 제거)
+    // ref.current가 null이어도 이벤트 리스너를 등록
+    // 이벤트 핸들러 내부에서 ref.current를 체크
     document.addEventListener('pointerdown', onPointerDown);
     document.addEventListener('keydown', onKeyDown);
 

--- a/src/widget/HomePage/HomePage.tsx
+++ b/src/widget/HomePage/HomePage.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Dropdown from '@/shared/ui/Dropdown/Dropdown';
 import { motion, useScroll, useTransform } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -11,13 +10,6 @@ export default function HomePage() {
 
   return (
     <main className="pb-80">
-      <Dropdown
-        options={[
-          { label: 'a', value: 'a' },
-          { label: 'ab', value: 'ab' },
-          { label: 'ac', value: 'abc' },
-        ]}
-      />
       <motion.div style={{ y }}>
         <div className="relative aspect-1920/1080 w-full">
           <Image src="/Images/illust_01.png" alt="배경 이미지" fill priority sizes="100vw" />


### PR DESCRIPTION
## PR 개요
- Popover 컴포넌트 구현

## 관련 이슈

- close #10

## PR 설명
### `Popover.tsx`
- Popover의 루트 컴포넌트로, provider로 감싸서 Trigger, Content에 상태 공유를 함
- 컴파운드 패턴으로 PopoverTrigger, PopoverContent 포함
### `PopoverContent.tsx`
- `createPortal`을 사용하여 body에 렌더링
- `usePopoverPosition`으로 렌더링할 위치를 계산
- 최소 공통 디자인 정의
### `PopoverContext.tsx`
- Popover 상태 관리를 위한 context 정의
### `PopoverProvider.tsx`
- Popover 상태 관리 및 context 제공
### `PopoverTrigger.tsx`
- Trigger가 되는 컴포넌트 범위를 열어두기 위해 `TriggerProps`를 정의하여 children 타입으로 둠 (ButtonWrapper, Profile 등의 경우 고려)
- 렌더링 중 ref 정의 eslint 에러를 막기 위해 `eslint-disabled-next-line react-hooks/immutability` 작성
### `usePopoverPosition.ts`
- `@floating-ui/react-dom`을 사용한 위치 계산 훅
- `offset(6)`으로 Popover에 대한 디자인을 하드코딩하여, 범용 커스텀훅을 원할 시, 해당 부분 수정 필요
