### PR TITLE
feat: add popover to download (#60)

### DIFF
--- a/src/app/api/download/route.ts
+++ b/src/app/api/download/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// 보안을 위해 허용된 호스트 화이트리스트
+const ALLOWED_R2_HOST = process.env.NEXT_PUBLIC_R2_DOMAIN;
+
+export async function GET(request: NextRequest) {
+  if (!ALLOWED_R2_HOST) {
+    return NextResponse.json({ error: 'Server configuration error' }, { status: 500 });
+  }
+  try {
+    const { searchParams } = new URL(request.url);
+    const url = searchParams.get('url');
+    const filename = searchParams.get('filename') || 'download';
+
+    if (!url) {
+      return NextResponse.json({ error: 'URL is required' }, { status: 400 });
+    }
+
+    // SSRF 방지: 허용된 호스트인지 확인
+    let targetUrl: URL;
+    try {
+      targetUrl = new URL(url);
+      if (targetUrl.host !== ALLOWED_R2_HOST) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    } catch {
+      return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+    }
+
+    // Cloudflare에서 파일 스트리밍
+    const response = await fetch(url, { signal: AbortSignal.timeout(30_000) }); // 15초 타임아웃
+    if (!response.ok) throw new Error('Failed to fetch file');
+
+    // 스트리밍 처리를 위해 body가 없을 경우 예외 처리
+    if (!response.body) {
+      throw new Error('No content body found');
+    }
+
+    // body 스트림을 직접 사용하여 메모리 절약
+    const contentType = response.headers.get('Content-Type') || 'application/octet-stream';
+
+    const safeFilename = filename.replace(/[\r\n"]/g, '').trim();
+    // ASCII fallback: 비 ASCII 문자를 제거
+    const asciiFilename = safeFilename.replace(/[^\x20-\x7E]/g, '_');
+    const encodedFilename = encodeURIComponent(safeFilename)
+      .replace(/['()]/g, c => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
+      .replace(/\*/g, '%2A');
+
+    return new NextResponse(response.body, {
+      headers: {
+        'Content-Type': contentType,
+        // attachment 설정으로 브라우저에서 파일을 열지 않고 바로 다운로드
+        'Content-Disposition': `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodedFilename}`,
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+      },
+    });
+  } catch (error) {
+    console.error('Download error:', error);
+    return NextResponse.json({ error: 'Download failed' }, { status: 500 });
+  }
+}

--- a/src/data/cards.ts
+++ b/src/data/cards.ts
@@ -198,10 +198,9 @@ export const CardDatas = [
     fileUrls: [
       'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/p_turtle_240922.ai',
       'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/p_turtle_240922.pdf',
-      'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/p_turtle_240922_%E1%84%83%E1%85%A2%E1%84%8C%E1%85%B5%201.png',
+      'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/p_turtle_240922.png',
     ],
-    thumbnail:
-      'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/p_turtle_240922_%E1%84%83%E1%85%A2%E1%84%8C%E1%85%B5%201.png',
+    thumbnail: 'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/p_turtle_240922.png',
     createdAt: '2024-09-22',
   },
   {
@@ -1008,10 +1007,9 @@ export const CardDatas = [
     fileUrls: [
       'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/wp_illust_dandelion_220820.ai',
       'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/wp_illust_dandelion_220820.pdf',
-      'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/wp_illust_dandelion_220820_%E1%84%83%E1%85%A2%E1%84%8C%E1%85%B5%201.png',
+      'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/wp_illust_dandelion_220820.png',
     ],
-    thumbnail:
-      'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/wp_illust_dandelion_220820_%E1%84%83%E1%85%A2%E1%84%8C%E1%85%B5%201.png',
+    thumbnail: 'https://pub-c055a1822d244b0aaba0dc63c00dcba2.r2.dev/wp_illust_dandelion_220820.png',
     createdAt: '2022-08-20',
   },
   {

--- a/src/shared/ui/Card/Card.tsx
+++ b/src/shared/ui/Card/Card.tsx
@@ -3,6 +3,7 @@ import { Card as CardType } from '@/types/card.types';
 import Image from 'next/image';
 
 import IconButton from '../IconButton/IconButton';
+import Popover from '../Popover/Popover';
 import Tag from './Tag/Tag';
 
 export default function Card({ id, title, tags, fileUrls, thumbnail, createdAt }: CardType) {
@@ -11,7 +12,7 @@ export default function Card({ id, title, tags, fileUrls, thumbnail, createdAt }
 
   const formattedDate = isValidDate
     ? date.toLocaleDateString('ko-KR', {
-        year: '2-digit', // 2자리 연도
+        year: '2-digit',
         month: '2-digit',
         day: '2-digit',
       })
@@ -22,6 +23,25 @@ export default function Card({ id, title, tags, fileUrls, thumbnail, createdAt }
 
   const handleCardClick = () => {
     open('CARDMORE', { id, title, thumbnail });
+  };
+
+  const handleDownload = (url: string, extension: string) => {
+    const filename = `${title}.${extension.toLowerCase()}`;
+    const downloadUrl = `/api/download?url=${encodeURIComponent(url)}&filename=${encodeURIComponent(filename)}`;
+
+    const link = document.createElement('a');
+    link.href = downloadUrl;
+
+    // 다운로드 속성 명시
+    link.setAttribute('download', filename);
+
+    document.body.appendChild(link);
+    link.click();
+
+    // 가비지 컬렉션 유도
+    setTimeout(() => {
+      document.body.removeChild(link);
+    }, 100);
   };
 
   return (
@@ -58,15 +78,35 @@ export default function Card({ id, title, tags, fileUrls, thumbnail, createdAt }
           <span className="text-gray400 font-label-xs">
             제작일 | <time dateTime={isoDate}>{formattedDate}</time>
           </span>
-          <IconButton
-            icon="IC_Download"
-            variant="ghost"
-            ariaLabel="파일 다운"
-            onClick={(e: React.MouseEvent) => {
-              e.stopPropagation();
-              // TODO: 추후 팝오버로 교체
-            }}
-          />
+          <Popover placement="top-end">
+            <Popover.Trigger popoverKey="menu">
+              <IconButton icon="IC_Download" variant="ghost" ariaLabel="파일 다운" />
+            </Popover.Trigger>
+            <Popover.Content popoverKey="menu">
+              {close => (
+                <div role="menu">
+                  {fileUrls.map((url, index) => {
+                    const extensionMatch = url.match(/\.(\w+)(\?|$)/);
+                    const extension = extensionMatch ? extensionMatch[1].toUpperCase() : 'FILE';
+
+                    return (
+                      <button
+                        key={`${id}-file-${index}`}
+                        role="menuitem"
+                        onClick={() => {
+                          handleDownload(url, extension);
+                          close();
+                        }}
+                        className="text-gray700 hover:bg-gray50 block w-full px-4 py-2 text-left text-sm transition-colors duration-150"
+                      >
+                        {extension} 다운로드
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </Popover.Content>
+          </Popover>
         </div>
       </div>
     </div>

--- a/src/shared/ui/Popover/PopoverContent.tsx
+++ b/src/shared/ui/Popover/PopoverContent.tsx
@@ -51,11 +51,12 @@ const PopoverContent = ({ children, popoverKey, className }: PopoverContentProps
       }}
       style={floatingStyles}
       className={clsx(
-        'border-gray100 bg-gray50 z-50 m-1 rounded-2xl border shadow-[0_1px_3px_1px_rgba(0,0,0,0.08),0_1px_5px_2px_rgba(0,0,0,0.02)]',
+        'border-gray100 z-50 m-1 overflow-hidden rounded-2xl border bg-white shadow-[0_1px_3px_1px_rgba(0,0,0,0.08),0_1px_5px_2px_rgba(0,0,0,0.02)]',
         className
       )}
       aria-modal="false"
       role="dialog"
+      onClick={e => e.stopPropagation()}
     >
       {children(close)}
     </div>,

--- a/src/shared/ui/Popover/PopoverTrigger.tsx
+++ b/src/shared/ui/Popover/PopoverTrigger.tsx
@@ -28,6 +28,7 @@ const PopoverTrigger = ({ children, popoverKey, ariaLabel }: PopoverTriggerProps
   const isActive = activeKey === popoverKey;
 
   const handleInteraction = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
     // 원래 children의 onClick이 있다면 실행
     children.props.onClick?.(e);
 


### PR DESCRIPTION
## PR 개요
- 다운로드 팝오버를 추가하여 파일 다운 기능 추가

## 관련 이슈

- close #60

## PR 설명
### `route.ts`
- Card에서 단순 링크를 넣을 경우 → pdf, png는 브라우저에 보임
- 프론트에서 fetch 할 경우 → 다른 도메인을 사용하여 CORS에러 발생
- Next.js Route를 사용하여 즉시 다운로드 진행
- 허용된 도메인(R2 버킷)을 확인하여 SSRF 방지
- 한글 파일명 깨지지 않도록 방지
- cloudflare에 잘못올린 한글 포함된 링크를 한글없는(인코딩 없는) 파일명으로 변경하여 링크 수정

### `Card.tsx`
- `handleDownload`로 route주소를 통해 다운로드 진행
- 기존 임시로 넣어둔 `IconButton`을 `Popover`로 교체
- Popover 클릭 시 상위 컴포넌트 이벤트 방지를 위해 Trigger, Content에 각각 버블링 방지 코드 작성